### PR TITLE
Firefox does not submit the radio as checked

### DIFF
--- a/js/radio.js
+++ b/js/radio.js
@@ -51,7 +51,7 @@
         });
 
         if ($el.prop(d) == false) {
-          if (checked == false) $parent.addClass(ch) && $el.attr(ch, true);
+          if (checked == false) $parent.addClass(ch) && $el.attr(ch, true) && $el.prop(ch, true);
           $el.trigger(e);
 
           if (checked !== $el.prop(ch)) {


### PR DESCRIPTION
I needed to call $el.prop to get the `radio` checked working in firefox. Without this, the `radio` shows the `checked` attribute, but does not submit correctly.